### PR TITLE
Let shebang decide used shell

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -77,7 +77,7 @@ set-option -g status-style fg=black,bg=yellow
 
 # Automatically update DISPLAY env variable for all panes
 if-shell -b 'test -f "$HOME/.local/bin/display_update"' {
-	set-hook -g client-attached 'run-shell "sh $HOME/.local/bin/display_update"'
+	set-hook -g client-attached 'run-shell "$HOME/.local/bin/display_update"'
 }
 
 


### PR DESCRIPTION
Using 'sh' might not result in using 'bash' shell as the shebang says. This results in the script exiting with an error.

Assumes that the file have the executable flag set