### PR TITLE
display_update updates X11 authentication

### DIFF
--- a/bin/display_update
+++ b/bin/display_update
@@ -15,6 +15,7 @@
 # This script handles updating $DISPLAY within vim also
 
 NEW_DISPLAY=$DISPLAY
+NEW_XAUTH="$(xauth list "$DISPLAY")"
 # NEW_DISPLAY=$(tmux show-env | sed -n 's/^DISPLAY=//p')
 
 # Update $DISPLAY in bash, zsh and vim/nvim
@@ -24,6 +25,7 @@ do
     IFS=' ' read -ra pane_process <<< "$pane_process"
     if [[ "${pane_process[1]}" == "zsh" || "${pane_process[1]}" == "bash" ]]; then
         tmux send-keys -t ${pane_process[0]} "export DISPLAY=$NEW_DISPLAY" Enter
+        tmux send-keys -t ${pane_process[0]} "xauth add $NEW_XAUTH" Enter
     elif [[ "${pane_process[1]}" == *"vi"* ]]; then
         tmux send-keys -t ${pane_process[0]} Escape
         tmux send-keys -t ${pane_process[0]} ":let \$DISPLAY = \"$NEW_DISPLAY\"" Enter


### PR DESCRIPTION
Might need a little bit more testing and see that it doesn't mess in some other cases.

Solves issue with same display 'xauth list' entry but actual different displays and authentication tokens.

Issue example:
In host machine A
1. Enter tmux session
2. Enter distrobox container * X11 authentication works good
3. Detach tmux session

In host machine B
1. SSH to host machine A
2. Enter distrobox container * X11 authentication does NOT work anymore

This is because in both examples, the same display e.g.
    DISPLAY=localhost:10.0
is used. Whereas the 2 different machines use different tokens, but as the :10 display already exists in 'xauth list' it doesn't update.